### PR TITLE
fix: lock globally installed npm packages

### DIFF
--- a/.github/workflows/glue.yml
+++ b/.github/workflows/glue.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Install & Setup node-aws-env
         run: |
           cd ./node-aws-env
-          npm install -g typescript eslint mocha
+          npm install -g typescript@5.4.5 eslint@8.57.0 mocha@10.4.0
           npm install
           tsc
 


### PR DESCRIPTION
Locks typescript, mocha and eslint