### PR TITLE
update to latest node LTS

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -18,7 +18,7 @@ on:
       cypress_image:
         type: string
         required: false
-        default: "cypress/browsers:node18.12.0-chrome106-ff106"
+        default: "cypress/browsers:node-20.14.0-chrome-125.0.6422.141-1-ff-126.0.1-edge-125.0.2535.85-1"
       vercel_org_id:
         type: string
         required: true


### PR DESCRIPTION
Next.js > v14 requires node > v18.17. Since the first Cypress image that is higher than v18.17 is in the 20s we might as well jump to LTS.