### PR TITLE
feat: add ci env variable for test

### DIFF
--- a/.github/workflows/glue.yml
+++ b/.github/workflows/glue.yml
@@ -97,6 +97,7 @@ jobs:
         if: ${{ inputs.stage != 'production' }}
         env:
           stage: ${{ inputs.stage }}
+          CI: true
         run: |
           cd ./checkout${{ inputs.api_dir }}
           [ -f test/env.${{ inputs.stage }}.txt ] && mv test/env.${{ inputs.stage }}.txt test/env.txt


### PR DESCRIPTION
In some of our tests we use the CI env variable to check if we should publish events - for example https://github.com/holdbar-com/api-events/blob/f87f6d89b4544a1a5a974aec8a9860c388b69a3d/lib/sns.ts#L35

It appears though, that the event is still published and it is causing a lot of errors in booking reminder system, because the company can then not be found.

So adding the CI env here to the test - was unsure if the CI should generally be set for all jobs and then NODE_ENV = test for the test...