### PR TITLE
chore: use 1.0.5 node-aws-env to allow static files

### DIFF
--- a/.github/workflows/glue.yml
+++ b/.github/workflows/glue.yml
@@ -57,7 +57,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: holdbar-com/node-aws-env
-          ref: v1.0.4
+          ref: v1.0.5
           path: "./node-aws-env"
           ssh-key: ${{ secrets.hb_github_ssh_key }}
 


### PR DESCRIPTION
Bump node-aws-env to 1.0.5 to allow static files