### PR TITLE
Feature/deploy lambdas image uri

### DIFF
--- a/.github/workflows/lambda-ecr.yml
+++ b/.github/workflows/lambda-ecr.yml
@@ -28,7 +28,8 @@ jobs:
     name: 'Build & Push Image'
     runs-on: ubuntu-latest
     outputs:
-      image_repo_tag: ${{ inputs.ecr_repository_name }}/${{ inputs.image_tag_prefix }}${{ github.run_number }}
+      image_repo: ${{ inputs.ecr_repository_name }}
+      image_tag: ${{ inputs.image_tag_prefix }}${{ github.run_number }}
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -87,7 +88,5 @@ jobs:
           role-duration-seconds: 900
 
       - name: Update lambda image uri
-        env:
-          IMAGE_URI: ${{ steps.login-ecr.outputs.registry }}/${{ needs.build.outputs.image_repo_tag }}
         run: |
-          aws lambda update-function-code --function-name ${{ inputs.aws_function_name }} --image-uri $IMAGE_URI
+          aws lambda update-function-code --function-name ${{ inputs.aws_function_name }} --image-uri ${{ steps.login-ecr.outputs.registry }}/${{ needs.build.outputs.image_repo }}:${{ needs.build.outputs.image_tag }}

--- a/.github/workflows/lambda-ecr.yml
+++ b/.github/workflows/lambda-ecr.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       image_repo: ${{ inputs.ecr_repository_name }}
-      image_tag: ${{ inputs.image_tag_prefix }}${{ github.run_number }}
+      image_tag: ${{ inputs.image_tag_prefix }}latest
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/lambda-ecr.yml
+++ b/.github/workflows/lambda-ecr.yml
@@ -28,7 +28,8 @@ jobs:
     name: 'Build & Push Image'
     runs-on: ubuntu-latest
     outputs:
-      image_uri: ${{ steps.push-image.outputs.image_uri }}
+      image_uri: ${{ steps.push_image.outputs.image_uri }}
+      ecr_registry: ${{ steps.push_image.outputs.ecr_registry }}
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -47,7 +48,7 @@ jobs:
           name: ${{ inputs.artifacts_name }}
 
       - name: Build Docker Image, tag, and push image to Amazon ECR
-        id: push-image
+        id: push_image
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: ${{ inputs.ecr_repository_name }}
@@ -60,6 +61,7 @@ jobs:
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:${{ inputs.image_tag_prefix }}$GITHUB_RUN_NUMBER
 
           echo "image_uri=$ECR_REGISTRY/$ECR_REPOSITORY:${{ inputs.image_tag_prefix }}$GITHUB_RUN_NUMBER" >> $GITHUB_OUTPUT
+          echo "ecr_registry=$ECR_REGISTRY" >> $GITHUB_OUTPUT
 
   trigger-deploy:
     if: inputs.aws_function_name != ''
@@ -77,4 +79,6 @@ jobs:
           role-duration-seconds: 900
       - name: Update lambda image uri
         run: |
+          echo "image_uri: ${{ needs.build.outputs.image_uri }}"
+          echo "ecr_registry: ${{ needs.build.outputs.ecr_registry }}"
           aws lambda update-function-code --function-name ${{ inputs.aws_function_name }} --image-uri ${{ needs.build.outputs.image_uri }}

--- a/.github/workflows/lambda-ecr.yml
+++ b/.github/workflows/lambda-ecr.yml
@@ -76,4 +76,4 @@ jobs:
           role-duration-seconds: 900
       - name: Update lambda image uri
         run: |
-          aws lambda update-function-code --function-name ${{ inputs.aws_function_name }} --image-uri ${{ needs.build.outputs.IMAGE_URI }} --profile holdbar-dev
+          aws lambda update-function-code --function-name ${{ inputs.aws_function_name }} --image-uri ${{ needs.build.outputs.IMAGE_URI }}

--- a/.github/workflows/lambda-ecr.yml
+++ b/.github/workflows/lambda-ecr.yml
@@ -28,7 +28,7 @@ jobs:
     name: 'Build & Push Image'
     runs-on: ubuntu-latest
     outputs:
-      image-uri: '${{ steps.login-ecr.outputs.registry }}/${{ inputs.ecr_repository_name }}:${{ inputs.image_tag_prefix }}$GITHUB_RUN_NUMBER'
+      image_uri: ${{ steps.push-image.outputs.image_uri }}
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -47,6 +47,7 @@ jobs:
           name: ${{ inputs.artifacts_name }}
 
       - name: Build Docker Image, tag, and push image to Amazon ECR
+        id: push-image
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: ${{ inputs.ecr_repository_name }}
@@ -57,6 +58,8 @@ jobs:
 
           docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$GITHUB_SHA $ECR_REGISTRY/$ECR_REPOSITORY:${{ inputs.image_tag_prefix }}$GITHUB_RUN_NUMBER
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:${{ inputs.image_tag_prefix }}$GITHUB_RUN_NUMBER
+
+          echo "image_uri=$ECR_REGISTRY/$ECR_REPOSITORY:${{ inputs.image_tag_prefix }}$GITHUB_RUN_NUMBER" >> $GITHUB_OUTPUT
 
   trigger-deploy:
     if: inputs.aws_function_name != ''
@@ -74,4 +77,4 @@ jobs:
           role-duration-seconds: 900
       - name: Update lambda image uri
         run: |
-          aws lambda update-function-code --function-name ${{ inputs.aws_function_name }} --image-uri ${{ needs.build.outputs.image-uri }}
+          aws lambda update-function-code --function-name ${{ inputs.aws_function_name }} --image-uri ${{ needs.build.outputs.image_uri }}

--- a/.github/workflows/lambda-ecr.yml
+++ b/.github/workflows/lambda-ecr.yml
@@ -28,7 +28,7 @@ jobs:
     name: 'Build & Push Image'
     runs-on: ubuntu-latest
     outputs:
-      image-uri: ${{ steps.login-ecr.outputs.registry }}/${{ inputs.ecr_repository_name }}:${{ inputs.image_tag_prefix }}$GITHUB_RUN_NUMBER
+      image-uri: '${{ steps.login-ecr.outputs.registry }}/${{ inputs.ecr_repository_name }}:${{ inputs.image_tag_prefix }}$GITHUB_RUN_NUMBER'
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/lambda-ecr.yml
+++ b/.github/workflows/lambda-ecr.yml
@@ -27,10 +27,8 @@ jobs:
   build:
     name: 'Build & Push Image'
     runs-on: ubuntu-latest
-    env:
-      IMAGE_URI: $ECR_REGISTRY/$ECR_REPOSITORY:${{ inputs.image_tag_prefix }}$GITHUB_RUN_NUMBER
     outputs:
-      IMAGE_URI: ${{env.IMAGE_URI}}
+      IMAGE_URI: ${{ steps.login-ecr.outputs.registry }}/${{ inputs.ecr_repository_name }}:${{ inputs.image_tag_prefix }}$GITHUB_RUN_NUMBER
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/lambda-ecr.yml
+++ b/.github/workflows/lambda-ecr.yml
@@ -28,7 +28,7 @@ jobs:
     name: 'Build & Push Image'
     runs-on: ubuntu-latest
     outputs:
-      image_repo_tag: ${{ inputs.ecr_repository_name }}/${{ inputs.image_tag_prefix }}$GITHUB_RUN_NUMBER
+      image_repo_tag: ${{ inputs.ecr_repository_name }}/${{ inputs.image_tag_prefix }}${{ github.run_number }}
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -56,8 +56,8 @@ jobs:
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$GITHUB_SHA .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$GITHUB_SHA
 
-          docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$GITHUB_SHA $ECR_REGISTRY/$ECR_REPOSITORY:${{ inputs.image_tag_prefix }}$GITHUB_RUN_NUMBER
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:${{ inputs.image_tag_prefix }}$GITHUB_RUN_NUMBER
+          docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$GITHUB_SHA $ECR_REGISTRY/$ECR_REPOSITORY:${{ inputs.image_tag_prefix }}${{ github.run_number }}
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:${{ inputs.image_tag_prefix }}${{ github.run_number }}
 
   trigger-deploy:
     if: inputs.aws_function_name != ''

--- a/.github/workflows/lambda-ecr.yml
+++ b/.github/workflows/lambda-ecr.yml
@@ -28,7 +28,7 @@ jobs:
     name: 'Build & Push Image'
     runs-on: ubuntu-latest
     outputs:
-      IMAGE_URI: ${{ steps.login-ecr.outputs.registry }}/${{ inputs.ecr_repository_name }}:${{ inputs.image_tag_prefix }}$GITHUB_RUN_NUMBER
+      image-uri: ${{ steps.login-ecr.outputs.registry }}/${{ inputs.ecr_repository_name }}:${{ inputs.image_tag_prefix }}$GITHUB_RUN_NUMBER
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -74,4 +74,4 @@ jobs:
           role-duration-seconds: 900
       - name: Update lambda image uri
         run: |
-          aws lambda update-function-code --function-name ${{ inputs.aws_function_name }} --image-uri ${{ needs.build.outputs.IMAGE_URI }}
+          aws lambda update-function-code --function-name ${{ inputs.aws_function_name }} --image-uri ${{ needs.build.outputs.image-uri }}

--- a/.github/workflows/lambda-ecr.yml
+++ b/.github/workflows/lambda-ecr.yml
@@ -58,7 +58,9 @@ jobs:
           docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$GITHUB_SHA $ECR_REGISTRY/$ECR_REPOSITORY:${{ inputs.image_tag_prefix }}${{ github.run_number }}
           docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$GITHUB_SHA $ECR_REGISTRY/$ECR_REPOSITORY:${{ inputs.image_tag_prefix }}latest
 
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$GITHUB_SHA --all-tags
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$GITHUB_SHA
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:${{ inputs.image_tag_prefix }}${{ github.run_number }}
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:${{ inputs.image_tag_prefix }}latest
 
   trigger-deploy:
     if: inputs.aws_function_name != ''

--- a/.github/workflows/lambda-ecr.yml
+++ b/.github/workflows/lambda-ecr.yml
@@ -80,13 +80,30 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
 
+      - name: Setup aws role arn
+        id: setup-aws-role-arn
+        env:
+          IMAGE_TAG_PREFIX: ${{ inputs.image_tag_prefix }}
+        run: |
+          if [ "$IMAGE_TAG_PREFIX" = "prod-" ]; then
+            ROLE_ARN="arn:aws:iam::189949407637:role/ContinuousDeliveryRole"
+          elif [ "$IMAGE_TAG_PREFIX" = "stage-" ]; then
+            ROLE_ARN="arn:aws:iam::446474216075:role/ContinuousDeliveryRole"
+          else
+            ROLE_ARN="arn:aws:iam::115578597962:role/ContinuousDeliveryRole"
+          fi
+
+          echo "ROLE_TO_ASSUME=$ROLE_ARN" >> $GITHUB_ENV
+
       - name: Configure AWS credentials
+        env:
+          ROLE_TO_ASSUME: ${{ env.ROLE_TO_ASSUME }}
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.aws_access_key_id }}
           aws-secret-access-key: ${{ secrets.aws_secret_access_key }}
           aws-region: ${{ secrets.aws_region }}
-          role-to-assume: arn:aws:iam::115578597962:role/ContinuousDeliveryRole
+          role-to-assume: ${{ env.ROLE_TO_ASSUME }}
           role-duration-seconds: 900
 
       - name: Update lambda image uri

--- a/.github/workflows/lambda-ecr.yml
+++ b/.github/workflows/lambda-ecr.yml
@@ -73,7 +73,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.aws_secret_access_key }}
           aws-region: ${{ secrets.aws_region }}
           role-to-assume: arn:aws:iam::115578597962:role/ContinuousDeliveryRole
-          role-duration-seconds: 120
+          role-duration-seconds: 900
       - name: Update lambda image uri
         run: |
           aws lambda update-function-code --function-name ${{ inputs.aws_function_name }} --image-uri ${{ needs.build.outputs.IMAGE_URI }} --profile holdbar-dev

--- a/.github/workflows/lambda-ecr.yml
+++ b/.github/workflows/lambda-ecr.yml
@@ -55,10 +55,10 @@ jobs:
         run: |
 
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$GITHUB_SHA .
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$GITHUB_SHA
-
           docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$GITHUB_SHA $ECR_REGISTRY/$ECR_REPOSITORY:${{ inputs.image_tag_prefix }}${{ github.run_number }}
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:${{ inputs.image_tag_prefix }}${{ github.run_number }}
+          docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$GITHUB_SHA $ECR_REGISTRY/$ECR_REPOSITORY:${{ inputs.image_tag_prefix }}latest
+
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$GITHUB_SHA --all-tags
 
   trigger-deploy:
     if: inputs.aws_function_name != ''

--- a/.github/workflows/lambda-ecr.yml
+++ b/.github/workflows/lambda-ecr.yml
@@ -28,8 +28,7 @@ jobs:
     name: 'Build & Push Image'
     runs-on: ubuntu-latest
     outputs:
-      image_uri: ${{ steps.push_image.outputs.image_uri }}
-      ecr_registry: ${{ steps.push_image.outputs.ecr_registry }}
+      image_repo_tag: ${{ inputs.ecr_repository_name }}/${{ inputs.image_tag_prefix }}$GITHUB_RUN_NUMBER
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -60,9 +59,6 @@ jobs:
           docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$GITHUB_SHA $ECR_REGISTRY/$ECR_REPOSITORY:${{ inputs.image_tag_prefix }}$GITHUB_RUN_NUMBER
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:${{ inputs.image_tag_prefix }}$GITHUB_RUN_NUMBER
 
-          echo "image_uri=$ECR_REGISTRY/$ECR_REPOSITORY:${{ inputs.image_tag_prefix }}$GITHUB_RUN_NUMBER" >> $GITHUB_OUTPUT
-          echo "ecr_registry=$ECR_REGISTRY" >> $GITHUB_OUTPUT
-
   trigger-deploy:
     if: inputs.aws_function_name != ''
     needs: [build]
@@ -75,10 +71,23 @@ jobs:
           aws-access-key-id: ${{ secrets.aws_access_key_id }}
           aws-secret-access-key: ${{ secrets.aws_secret_access_key }}
           aws-region: ${{ secrets.aws_region }}
+
+      # Needed here because it's a secret value so cannot be passed as an output from the build job
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.aws_access_key_id }}
+          aws-secret-access-key: ${{ secrets.aws_secret_access_key }}
+          aws-region: ${{ secrets.aws_region }}
           role-to-assume: arn:aws:iam::115578597962:role/ContinuousDeliveryRole
           role-duration-seconds: 900
+
       - name: Update lambda image uri
+        env:
+          IMAGE_URI: ${{ steps.login-ecr.outputs.registry }}/${{ needs.build.outputs.image_repo_tag }}
         run: |
-          echo "image_uri: ${{ needs.build.outputs.image_uri }}"
-          echo "ecr_registry: ${{ needs.build.outputs.ecr_registry }}"
-          aws lambda update-function-code --function-name ${{ inputs.aws_function_name }} --image-uri ${{ needs.build.outputs.image_uri }}
+          aws lambda update-function-code --function-name ${{ inputs.aws_function_name }} --image-uri $IMAGE_URI

--- a/.github/workflows/lambda-ecr.yml
+++ b/.github/workflows/lambda-ecr.yml
@@ -1,4 +1,4 @@
-name: "Build & Push Image"
+name: 'Build & Push Image'
 
 on:
   workflow_call:
@@ -6,6 +6,9 @@ on:
       ecr_repository_name:
         type: string
         required: true
+      aws_function_name:
+        type: string
+        required: false
       image_tag_prefix:
         type: string
         required: true
@@ -22,8 +25,12 @@ on:
 
 jobs:
   build:
-    name: "Build & Push Image"
+    name: 'Build & Push Image'
     runs-on: ubuntu-latest
+    env:
+      IMAGE_URI: $ECR_REGISTRY/$ECR_REPOSITORY:${{ inputs.image_tag_prefix }}$GITHUB_RUN_NUMBER
+    outputs:
+      IMAGE_URI: ${{env.IMAGE_URI}}
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -46,9 +53,27 @@ jobs:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: ${{ inputs.ecr_repository_name }}
         run: |
-          
+
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$GITHUB_SHA .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$GITHUB_SHA
-          
+
           docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$GITHUB_SHA $ECR_REGISTRY/$ECR_REPOSITORY:${{ inputs.image_tag_prefix }}$GITHUB_RUN_NUMBER
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:${{ inputs.image_tag_prefix }}$GITHUB_RUN_NUMBER
+
+  trigger-deploy:
+    if: inputs.aws_function_name != ''
+    needs: [build]
+    name: 'Trigger Deploy'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.aws_access_key_id }}
+          aws-secret-access-key: ${{ secrets.aws_secret_access_key }}
+          aws-region: ${{ secrets.aws_region }}
+          role-to-assume: arn:aws:iam::115578597962:role/ContinuousDeliveryRole
+          role-duration-seconds: 120
+      - name: Update lambda image uri
+        run: |
+          aws lambda update-function-code --function-name ${{ inputs.aws_function_name }} --image-uri ${{ needs.build.outputs.IMAGE_URI }} --profile holdbar-dev

--- a/.github/workflows/repo-data.yml
+++ b/.github/workflows/repo-data.yml
@@ -36,7 +36,7 @@ jobs:
             IMAGE_TAG="stage-"
           elif [ "$GITHUB_REF_NAME" = "hotfix/"* ]; then
             IMAGE_TAG="stage-"
-          elfi [ "$WORKFLOW_TRIGGER" = "pull_request" ]; then
+          elif [ "$WORKFLOW_TRIGGER" = "pull_request" ]; then
             IMAGE_TAG="stage-"
           else
             IMAGE_TAG="dev-"

--- a/.github/workflows/repo-data.yml
+++ b/.github/workflows/repo-data.yml
@@ -24,10 +24,6 @@ jobs:
           WORKFLOW_TRIGGER: ${{ github.event_name }}
         run: |
 
-          echo "workflow trigger $WORKFLOW_TRIGGER"
-          echo "event_name ${{ github.event_name}} ""
-          echo "event action ${{ github.event.action}} ""
-
           if [ "$GITHUB_REF_NAME" = "main" ]; then
             IMAGE_TAG="prod-"
           elif [ "$GITHUB_REF_NAME" = "master" ]; then

--- a/.github/workflows/repo-data.yml
+++ b/.github/workflows/repo-data.yml
@@ -23,6 +23,11 @@ jobs:
         env:
           WORKFLOW_TRIGGER: ${{ github.event_name }}
         run: |
+
+          echo "workflow trigger $WORKFLOW_TRIGGER"
+          echo "event_name ${{ github.event_name}} ""
+          echo "event action ${{ github.event.action}} ""
+
           if [ "$GITHUB_REF_NAME" = "main" ]; then
             IMAGE_TAG="prod-"
           elif [ "$GITHUB_REF_NAME" = "master" ]; then

--- a/.github/workflows/repo-data.yml
+++ b/.github/workflows/repo-data.yml
@@ -1,10 +1,10 @@
-name: "Extract Repository Data"
+name: 'Extract Repository Data'
 
 on:
   workflow_call:
     outputs:
       repository_name:
-        description: "Base repository name, without organization"
+        description: 'Base repository name, without organization'
         value: ${{ jobs.extract-data.outputs.repository_name }}
       image_tag_prefix:
         description: Determined based on the branch name. Is either `prod-`, `stage-` or `dev-`"
@@ -12,7 +12,7 @@ on:
 
 jobs:
   extract-data:
-    name: "Data Setup"
+    name: 'Data Setup'
     runs-on: ubuntu-latest
     outputs:
       repository_name: ${{ steps.set_data.outputs.repo_name }}
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Set Outputs
         id: set_data
+        env:
+          WORKFLOW_TRIGGER: ${{ github.event_name }}
         run: |
           if [ "$GITHUB_REF_NAME" = "main" ]; then
             IMAGE_TAG="prod-"
@@ -29,12 +31,14 @@ jobs:
             IMAGE_TAG="stage-"
           elif [ "$GITHUB_REF_NAME" = "hotfix/"* ]; then
             IMAGE_TAG="stage-"
+          elfi [ "$WORKFLOW_TRIGGER" = "pull_request" ]; then
+            IMAGE_TAG="stage-"
           else
             IMAGE_TAG="dev-"
           fi
-          
+
           repo="${{ github.repository }}"
           REPO_NAME=${repo#*/}
-          
+
           echo "repo_name=$REPO_NAME" >> $GITHUB_OUTPUT
           echo "image_tag_prefix=$IMAGE_TAG" >> $GITHUB_OUTPUT


### PR DESCRIPTION
I have been using this automated workflow a lot on the [payments](https://github.com/holdbar-com/payments/actions/runs/11157440326) repo to deploy lambdas on build. I think it's quite nice to not having to update terraform each time.

If you think this is fine, we can merge it and use in other services too until we have  something like code deploy or similar