### PR TITLE
feat(release-drafter-go): split drafter and autolabeler (v7)

### DIFF
--- a/.github/workflows/release-drafter-go.yml
+++ b/.github/workflows/release-drafter-go.yml
@@ -4,8 +4,18 @@ on:
 jobs:
   update-release-draft:
     name: updating draft
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - uses: release-drafter/release-drafter@v7
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  autolabel:
+    name: autolabel
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter/autolabeler@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Why

In v6, the drafter ran on both \`push\` and \`pull_request\` and tried to update the draft release on every PR. That broke around 2026-04-22 because \`github.ref\` on \`pull_request\` events resolves to \`refs/pull/N/merge\`, which GitHub's \`update-a-release\` API rejects:

\`\`\`
Validation Failed: {"resource":"Release","code":"invalid","field":"target_commitish"}
\`\`\`

go-urpcauth has been red on every PR run since then (e.g. [run 24757721005](https://github.com/understory-io/go-urpcauth/actions/runs/24757721005)), and the same failure surfaced on the new [go-uopenapiauth](https://github.com/understory-io/go-uopenapiauth) repo. Related to US-8475 phase 3.

release-drafter [v7](https://github.com/release-drafter/release-drafter/pull/1475) moved the autolabeler into its own dedicated sub-action, which matches how we actually want this to run: the drafter on \`push\` to keep the draft up to date, the autolabeler on \`pull_request\` to label PRs for release-notes grouping. Splitting them removes the target_commitish collision entirely.

# Changes

- \`update-release-draft\` now gated to \`github.event_name == 'push'\`. Keeps target_commitish pointing at a real branch.
- New \`autolabel\` job gated to \`pull_request\`, using \`release-drafter/release-drafter/autolabeler@v7\`.
- Migrate from \`env.GITHUB_TOKEN\` to the new \`with.token\` input per v7's guide.

The shared \`.github/release-drafter.yml\` org config already uses arrays for \`branch\`/\`title\`/\`files\`/\`body\`/\`labels\`, so it satisfies v7's stricter schema without edits.

# Test plan

- [ ] Merge, confirm go-urpcauth's next PR has two green checks (drafter skipped, autolabel running) and the next push to main successfully updates the v0.x.y draft.
- [ ] Same verification on go-uopenapiauth#1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)