### PR TITLE
feat: add ci-go-mise-lambda shared workflow

### DIFF
--- a/.github/workflows/ci-go-mise-lambda.yml
+++ b/.github/workflows/ci-go-mise-lambda.yml
@@ -15,7 +15,7 @@ on:
         description: "LocalStack Docker image to use"
         required: false
         type: string
-        default: localstack/localstack
+        default: localstack/localstack:4.2.0
     secrets:
       go_private_modules_pat:
         required: true

--- a/.github/workflows/ci-go-mise-lambda.yml
+++ b/.github/workflows/ci-go-mise-lambda.yml
@@ -1,0 +1,107 @@
+name: CI Go Mise Lambda
+
+on:
+  workflow_call:
+    inputs:
+      app_name:
+        description: "Application name, used as the artifact name"
+        required: true
+        type: string
+      app_dir:
+        description: "Path to the application directory (e.g. apps/bookings-core)"
+        required: true
+        type: string
+      localstack_image:
+        description: "LocalStack Docker image to use"
+        required: false
+        type: string
+        default: localstack/localstack
+    secrets:
+      go_private_modules_pat:
+        required: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Configure access to private Go modules
+        env:
+          GO_PRIVATE_MODULES_PAT: ${{ secrets.go_private_modules_pat }}
+        run: |
+          git config --global \
+            url."https://understory-services:${GO_PRIVATE_MODULES_PAT}@github.com/understory-io".insteadOf \
+            "https://github.com/understory-io"
+          echo "GOPRIVATE=github.com/understory-io/*" >> $GITHUB_ENV
+          echo "GONOSUMDB=github.com/understory-io/*" >> $GITHUB_ENV
+
+      - name: Install Mise
+        uses: jdx/mise-action@v4
+
+      # Go caching strategy is based on https://danp.net/posts/github-actions-go-cache/
+      - name: Restore Go cache
+        uses: actions/cache/restore@v5
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: nonexistent
+          restore-keys: ${{ runner.os }}-go-${{ hashFiles(format('{0}/go.mod', inputs.app_dir)) }}-
+
+      - name: Download Go dependencies
+        run: cd ${{ inputs.app_dir }} && go mod download -x
+
+      - name: Restore LocalStack Docker image cache
+        uses: actions/cache@v5
+        with:
+          path: /tmp/localstack-image.tar
+          key: localstack-image-${{ runner.os }}-${{ inputs.localstack_image }}
+
+      - name: Load or pull LocalStack Docker image
+        run: |
+          if [ -f /tmp/localstack-image.tar ]; then
+            docker load -i /tmp/localstack-image.tar
+          else
+            docker pull ${{ inputs.localstack_image }}
+            docker save ${{ inputs.localstack_image }} -o /tmp/localstack-image.tar
+          fi
+
+      - name: Start LocalStack and run migrations
+        run: cd ${{ inputs.app_dir }} && mise local:up
+
+      - name: Run tests
+        run: cd ${{ inputs.app_dir }} && mise test
+        env:
+          GOFLAGS: "-mod=readonly"
+
+      - name: Build Lambda binary
+        run: cd ${{ inputs.app_dir }} && mise build
+        env:
+          GOFLAGS: "-mod=readonly"
+
+      - name: Archive build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.app_name }}
+          include-hidden-files: true
+          path: |
+            ./${{ inputs.app_dir }}/bin/**
+            ./${{ inputs.app_dir }}/Dockerfile
+
+      - name: Trim Go build cache
+        if: github.ref == 'refs/heads/main'
+        run: find ~/.cache/go-build -type f -mmin +90 -delete
+
+      - name: Set cache date
+        run: echo "GO_CACHE_DATE=$(date +%Y-%m-%d)" >> $GITHUB_ENV
+
+      - name: Save Go cache
+        if: github.ref == 'refs/heads/main'
+        uses: actions/cache/save@v5
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: "${{ runner.os }}-go-${{ hashFiles(format('{0}/go.mod', inputs.app_dir)) }}-${{ env.GO_CACHE_DATE }}"

--- a/.github/workflows/ci-go-mise-lambda.yml
+++ b/.github/workflows/ci-go-mise-lambda.yml
@@ -23,6 +23,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      AWS_ACCESS_KEY_ID: test
+      AWS_SECRET_ACCESS_KEY: test
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,6 +160,19 @@ This repository contains **shared GitHub Actions actions and workflows** used ac
 - **Purpose**: Draft releases for Go projects
 - **Trigger**: `workflow_call`
 
+#### 4. ci-go-mise-lambda (`ci-go-mise-lambda.yml`)
+
+- **Purpose**: Shared build/test/package job for mise-based Go Lambda services
+- **Trigger**: `workflow_call`
+- **Replaces**: Duplicated `build` jobs in per-service workflows (bookings-core, experience-core, storefronts-core)
+- **Key Inputs**:
+  - `app_name` (required): artifact name, e.g. "bookings-core"
+  - `app_dir` (required): path to the app, e.g. "apps/bookings-core"
+  - `localstack_image` (optional, default: `localstack/localstack`): allows pinning a specific version
+- **Key Secret**: `go_private_modules_pat`
+- **What it does**: checkout → private Go module config → Mise install → Go cache restore → `go mod download -x` → LocalStack cache/load → `mise local:up` → `mise test` → `mise build` → artifact upload → Go cache save (main only)
+- **Cache key fix**: uses `hashFiles(format('{0}/go.mod', inputs.app_dir))` to correctly hash the subdirectory go.mod (nested `${{ }}` inside `hashFiles()` is not evaluated by GitHub Actions)
+
 ### Utility Workflows
 
 #### 14. setup-node-aws-env (`setup-node-aws-env.yml`)


### PR DESCRIPTION
## Summary

- Adds `ci-go-mise-lambda.yml` — a reusable `workflow_call` workflow that extracts the duplicated `build` job shared by bookings-core, experience-core, and storefronts-core
- Fixes the broken `hashFiles` cache key: nested `${{ env.APP_DIR }}` inside `hashFiles()` is never evaluated by GitHub Actions, so the hash was always empty — replaced with `hashFiles(format('{0}/go.mod', inputs.app_dir))`
- Removes `go mod tidy` from CI (it mutates `go.mod`/`go.sum` and changes are silently discarded)
- Adds `-x` flag to `go mod download` for visibility
- Standardises to latest action versions (`checkout@v6`, `cache@v5`, `mise-action@v4`, `upload-artifact@v4`)
- Parameterises the LocalStack image so services can pin a specific version
- Updates CLAUDE.md with documentation for the new workflow

## Test plan

- [x] Open a draft PR in bookings referencing this branch (`feat/ci-go-mise-lambda`) to validate the workflow before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)