### PR TITLE
lambda-ecr: allow overriding deploy account id

### DIFF
--- a/.github/workflows/lambda-ecr.yml
+++ b/.github/workflows/lambda-ecr.yml
@@ -19,6 +19,11 @@ on:
         type: string
         required: false
         description: "The architecture to build for. This can be either arm64 or x86_64"
+      deploy_account_id:
+        type: string
+        required: false
+        default: ""
+        description: "AWS account id to assume into for the lambda deploy step. Overrides the prefix-based default (prod- → platform-prod, otherwise platform-dev). Use when the function lives in an account that doesn't match the image tag convention."
     secrets:
       aws_access_key_id:
         required: true
@@ -74,8 +79,11 @@ jobs:
         id: setup-aws-role-arn
         env:
           IMAGE_TAG_PREFIX: ${{ inputs.image_tag_prefix }}
+          DEPLOY_ACCOUNT_ID: ${{ inputs.deploy_account_id }}
         run: |
-          if [ "$IMAGE_TAG_PREFIX" = "prod-" ]; then
+          if [ -n "$DEPLOY_ACCOUNT_ID" ]; then
+            ROLE_ARN="arn:aws:iam::${DEPLOY_ACCOUNT_ID}:role/ContinuousDeliveryRole"
+          elif [ "$IMAGE_TAG_PREFIX" = "prod-" ]; then
             ROLE_ARN="arn:aws:iam::189949407637:role/ContinuousDeliveryRole"
           else
             ROLE_ARN="arn:aws:iam::115578597962:role/ContinuousDeliveryRole"


### PR DESCRIPTION
# Why

`cloudtrail-alarm-enricher` (and any future service in the same shape) is deployed to platform-dev only but consumes a `prod-`-tagged image from the centralised ECR. With the current hard-coded role logic, the deploy step on push-to-main assumes the platform-**prod** role, `aws lambda get-function` returns no match, `LAMBDA_EXISTS` is set to `false`, and `update-function-code` is silently skipped. The job reports success while no Lambda is actually updated — observed yesterday on https://github.com/understory-io/cloudtrail-alarm-enricher/pull/3 (skipped trigger-deploy).

# Changes

- New optional `deploy_account_id` input on `lambda-ecr.yml`. When set, the `ContinuousDeliveryRole` ARN is built from this account id, overriding the prefix-based default.
- Default behaviour preserved: unset input keeps `prod-` → 189949407637 and otherwise → 115578597962. No existing caller needs to change.

# Test plan

- [ ] Merge consumer PR in `cloudtrail-alarm-enricher` that sets `aws_function_name` + `deploy_account_id: "115578597962"` and confirm the next push-to-main runs Trigger Deploy against platform-dev and updates the Lambda image uri.