### PR TITLE
feat: add timeout-minutes to all shared workflow jobs

### DIFF
--- a/.github/workflows/build-deploy-netcore-library.yml
+++ b/.github/workflows/build-deploy-netcore-library.yml
@@ -1,6 +1,12 @@
 name: ".NET Core Library"
 on:
   workflow_call:
+    inputs:
+      timeout_minutes:
+        description: "Max minutes before the build job is cancelled (forwarded to build-netcore-library)"
+        type: number
+        required: false
+        default: 5
     secrets:
       nuget_auth_token:
         required: true
@@ -14,6 +20,7 @@ jobs:
       buildConfiguration: 'Debug'
       versionSuffix: alpha.${{ github.run_number }}
       nuget_username: ${{ github.actor }}
+      timeout_minutes: ${{ inputs.timeout_minutes }}
     secrets:
       nuget_auth_token: ${{ secrets.nuget_auth_token }}
 
@@ -24,6 +31,7 @@ jobs:
       buildConfiguration: 'Debug'
       versionSuffix: alpha.${{ github.run_number }}
       nuget_username: ${{ github.actor }}
+      timeout_minutes: ${{ inputs.timeout_minutes }}
     secrets:
       nuget_auth_token: ${{ secrets.nuget_auth_token }}
 
@@ -34,6 +42,7 @@ jobs:
       buildConfiguration: 'Release'
       versionSuffix: rc.${{ github.run_number }}
       nuget_username: ${{ github.actor }}
+      timeout_minutes: ${{ inputs.timeout_minutes }}
     secrets:
       nuget_auth_token: ${{ secrets.nuget_auth_token }}
 
@@ -44,5 +53,6 @@ jobs:
       buildConfiguration: 'Release'
       version: ${GITHUB_REF/refs\/tags\//}
       nuget_username: ${{ github.actor }}
+      timeout_minutes: ${{ inputs.timeout_minutes }}
     secrets:
       nuget_auth_token: ${{ secrets.nuget_auth_token }}

--- a/.github/workflows/build-netcore-library.yml
+++ b/.github/workflows/build-netcore-library.yml
@@ -27,6 +27,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/build-netcore-library.yml
+++ b/.github/workflows/build-netcore-library.yml
@@ -2,6 +2,11 @@ name: ".NET Core Library"
 on:
   workflow_call:
     inputs:
+      timeout_minutes:
+        description: "Max minutes before the job is cancelled (override the measured default)"
+        type: number
+        required: false
+        default: 5
       buildConfiguration:
         required: false
         type: string
@@ -27,7 +32,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: ${{ inputs.timeout_minutes }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/ci-go-library-mise.yml
+++ b/.github/workflows/ci-go-library-mise.yml
@@ -18,6 +18,7 @@ on:
 jobs:
   ci:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/ci-go-library-mise.yml
+++ b/.github/workflows/ci-go-library-mise.yml
@@ -6,6 +6,11 @@ on:
       go-private-modules-pat:
         required: true
     inputs:
+      timeout_minutes:
+        description: "Max minutes before the job is cancelled (override the measured default)"
+        type: number
+        required: false
+        default: 15
       localstack:
         type: boolean
         required: false
@@ -18,7 +23,7 @@ on:
 jobs:
   ci:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: ${{ inputs.timeout_minutes }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/ci-go-library.yml
+++ b/.github/workflows/ci-go-library.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   ci:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/ci-go-library.yml
+++ b/.github/workflows/ci-go-library.yml
@@ -2,6 +2,12 @@ name: CI
 
 on:
   workflow_call:
+    inputs:
+      timeout_minutes:
+        description: "Max minutes before the job is cancelled (override the measured default)"
+        type: number
+        required: false
+        default: 5
     secrets:
       go-private-modules-pat:
         required: true
@@ -9,7 +15,7 @@ on:
 jobs:
   ci:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: ${{ inputs.timeout_minutes }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/ci-go-mise-lambda.yml
+++ b/.github/workflows/ci-go-mise-lambda.yml
@@ -3,6 +3,11 @@ name: CI Go Mise Lambda
 on:
   workflow_call:
     inputs:
+      timeout_minutes:
+        description: "Max minutes before the job is cancelled (override the measured default)"
+        type: number
+        required: false
+        default: 20
       app_name:
         description: "Application name, used as the artifact name"
         required: true
@@ -28,7 +33,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: ${{ inputs.timeout_minutes }}
     env:
       AWS_ACCESS_KEY_ID: test
       AWS_SECRET_ACCESS_KEY: test

--- a/.github/workflows/ci-go-mise-lambda.yml
+++ b/.github/workflows/ci-go-mise-lambda.yml
@@ -28,6 +28,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     env:
       AWS_ACCESS_KEY_ID: test
       AWS_SECRET_ACCESS_KEY: test

--- a/.github/workflows/create-deployment-prs.yml
+++ b/.github/workflows/create-deployment-prs.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   release-prs:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     name: Update release PRs
 
     permissions:

--- a/.github/workflows/create-deployment-prs.yml
+++ b/.github/workflows/create-deployment-prs.yml
@@ -2,6 +2,11 @@ name: Update release PRs
 on:
   workflow_call:
     inputs:
+      timeout_minutes:
+        description: "Max minutes before the job is cancelled (override the measured default)"
+        type: number
+        required: false
+        default: 5
       promotionPairs:
         type: string
         required: true
@@ -13,7 +18,7 @@ on:
 jobs:
   release-prs:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: ${{ inputs.timeout_minutes }}
     name: Update release PRs
 
     permissions:

--- a/.github/workflows/crowdin-pull-translations.yml
+++ b/.github/workflows/crowdin-pull-translations.yml
@@ -34,6 +34,7 @@ permissions:
 jobs:
   pull-translations:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/crowdin-pull-translations.yml
+++ b/.github/workflows/crowdin-pull-translations.yml
@@ -3,6 +3,11 @@ name: Crowdin Pull Translations
 on:
   workflow_call:
     inputs:
+      timeout_minutes:
+        description: "Max minutes before the job is cancelled (override the measured default)"
+        type: number
+        required: false
+        default: 5
       crowdin-download-flags:
         description: 'Additional flags for crowdin download command (e.g., --branch main)'
         type: string
@@ -34,7 +39,7 @@ permissions:
 jobs:
   pull-translations:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: ${{ inputs.timeout_minutes }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -37,6 +37,7 @@ jobs:
   install:
     name: Install
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -58,6 +59,7 @@ jobs:
     name: E2E tests
     needs: install
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     container:
       image: ${{ inputs.cypress_image }}
     strategy:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -3,6 +3,11 @@ name: "Run all cypress-tests in a project"
 on:
   workflow_call:
     inputs:
+      timeout_minutes:
+        description: "Max minutes before the job is cancelled (override the measured default)"
+        type: number
+        required: false
+        default: 30
       config_file_path:
         type: string
         required: false
@@ -59,7 +64,7 @@ jobs:
     name: E2E tests
     needs: install
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: ${{ inputs.timeout_minutes }}
     container:
       image: ${{ inputs.cypress_image }}
     strategy:

--- a/.github/workflows/glue.yml
+++ b/.github/workflows/glue.yml
@@ -3,6 +3,11 @@ name: 'Build & Deploy Glue Lambda Service'
 on:
   workflow_call:
     inputs:
+      timeout_minutes:
+        description: "Max minutes before the job is cancelled (override the measured default)"
+        type: number
+        required: false
+        default: 18
       stage:
         type: string
         required: true
@@ -30,7 +35,7 @@ jobs:
   build:
     name: 'Build & Deploy Service'
     runs-on: ubuntu-latest
-    timeout-minutes: 18
+    timeout-minutes: ${{ inputs.timeout_minutes }}
     environment: ${{ inputs.stage }}
     steps:
       - name: Checkout

--- a/.github/workflows/glue.yml
+++ b/.github/workflows/glue.yml
@@ -30,6 +30,7 @@ jobs:
   build:
     name: 'Build & Deploy Service'
     runs-on: ubuntu-latest
+    timeout-minutes: 18
     environment: ${{ inputs.stage }}
     steps:
       - name: Checkout

--- a/.github/workflows/lambda-ecr.yml
+++ b/.github/workflows/lambda-ecr.yml
@@ -36,6 +36,7 @@ jobs:
   build:
     name: "Build & Push Image"
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       image_repo: ${{ inputs.ecr_repository_name }}
       image_tag: ${{ inputs.image_tag_prefix }}latest
@@ -62,6 +63,7 @@ jobs:
     needs: [build]
     name: "Trigger Deploy"
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6

--- a/.github/workflows/lambda-ecr.yml
+++ b/.github/workflows/lambda-ecr.yml
@@ -3,6 +3,11 @@ name: "Build & Push Image"
 on:
   workflow_call:
     inputs:
+      timeout_minutes:
+        description: "Max minutes before the job is cancelled (override the measured default)"
+        type: number
+        required: false
+        default: 10
       ecr_repository_name:
         type: string
         required: true
@@ -36,7 +41,7 @@ jobs:
   build:
     name: "Build & Push Image"
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: ${{ inputs.timeout_minutes }}
     outputs:
       image_repo: ${{ inputs.ecr_repository_name }}
       image_tag: ${{ inputs.image_tag_prefix }}latest

--- a/.github/workflows/lambda-netcore-ecr.yml
+++ b/.github/workflows/lambda-netcore-ecr.yml
@@ -45,6 +45,7 @@ jobs:
   build:
     name: "Build & Push Image"
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       image_repo: ${{ inputs.ecr_repository_name }}
       image_tag: ${{ inputs.image_tag_prefix }}latest
@@ -110,6 +111,7 @@ jobs:
     needs: [build]
     name: "Trigger Deploy"
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6

--- a/.github/workflows/lambda-netcore-ecr.yml
+++ b/.github/workflows/lambda-netcore-ecr.yml
@@ -3,6 +3,11 @@ name: "Build & Push Image"
 on:
   workflow_call:
     inputs:
+      timeout_minutes:
+        description: "Max minutes before the job is cancelled (override the measured default)"
+        type: number
+        required: false
+        default: 10
       dotnet_version:
         type: string
         required: false
@@ -45,7 +50,7 @@ jobs:
   build:
     name: "Build & Push Image"
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: ${{ inputs.timeout_minutes }}
     outputs:
       image_repo: ${{ inputs.ecr_repository_name }}
       image_tag: ${{ inputs.image_tag_prefix }}latest

--- a/.github/workflows/pixel-collector.yml
+++ b/.github/workflows/pixel-collector.yml
@@ -21,6 +21,7 @@ on:
 jobs:
   collect-usage:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6

--- a/.github/workflows/pixel-collector.yml
+++ b/.github/workflows/pixel-collector.yml
@@ -3,6 +3,11 @@ name: 'Collect components usage'
 on:
   workflow_call:
     inputs:
+      timeout_minutes:
+        description: "Max minutes before the job is cancelled (override the measured default)"
+        type: number
+        required: false
+        default: 5
       src_dir:
         type: string
         required: true
@@ -21,7 +26,7 @@ on:
 jobs:
   collect-usage:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: ${{ inputs.timeout_minutes }}
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6

--- a/.github/workflows/poeditor-check.yml
+++ b/.github/workflows/poeditor-check.yml
@@ -3,6 +3,11 @@ name: "Check that all POEditor Terms are translated"
 on:
   workflow_call:
     inputs:
+      timeout_minutes:
+        description: "Max minutes before the job is cancelled (override the measured default)"
+        type: number
+        required: false
+        default: 5
       poeditor_project:
         type: string
         required: true
@@ -14,7 +19,7 @@ jobs:
   build:
     name: "Check translations"
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: ${{ inputs.timeout_minutes }}
     steps:
       - name: Check translation percentage
         id: check_translation_status

--- a/.github/workflows/poeditor-check.yml
+++ b/.github/workflows/poeditor-check.yml
@@ -14,6 +14,7 @@ jobs:
   build:
     name: "Check translations"
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Check translation percentage
         id: check_translation_status

--- a/.github/workflows/publish-releases.yml
+++ b/.github/workflows/publish-releases.yml
@@ -1,6 +1,11 @@
 on:
   workflow_call:
     inputs:
+      timeout_minutes:
+        description: "Max minutes before the job is cancelled (override the measured default)"
+        type: number
+        required: false
+        default: 10
       publish-command:
         type: string
         required: true
@@ -50,7 +55,7 @@ jobs:
       packages: write
       pull-requests: write
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: ${{ inputs.timeout_minutes }}
     outputs:
       published: ${{ steps.changesets.outputs.published }}
     steps:

--- a/.github/workflows/publish-releases.yml
+++ b/.github/workflows/publish-releases.yml
@@ -50,6 +50,7 @@ jobs:
       packages: write
       pull-requests: write
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       published: ${{ steps.changesets.outputs.published }}
     steps:

--- a/.github/workflows/release-drafter-go.yml
+++ b/.github/workflows/release-drafter-go.yml
@@ -1,12 +1,18 @@
 on:
   workflow_call:
+    inputs:
+      timeout_minutes:
+        description: "Max minutes before the job is cancelled (override the measured default)"
+        type: number
+        required: false
+        default: 5
 
 jobs:
   update-release-draft:
     name: updating draft
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: ${{ inputs.timeout_minutes }}
     steps:
       - uses: release-drafter/release-drafter@v7
         with:
@@ -16,7 +22,7 @@ jobs:
     name: autolabel
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: ${{ inputs.timeout_minutes }}
     steps:
       - uses: release-drafter/release-drafter/autolabeler@v7
         with:

--- a/.github/workflows/release-drafter-go.yml
+++ b/.github/workflows/release-drafter-go.yml
@@ -6,6 +6,7 @@ jobs:
     name: updating draft
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: release-drafter/release-drafter@v7
         with:
@@ -15,6 +16,7 @@ jobs:
     name: autolabel
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: release-drafter/release-drafter/autolabeler@v7
         with:

--- a/.github/workflows/repo-data.yml
+++ b/.github/workflows/repo-data.yml
@@ -2,6 +2,12 @@ name: "Extract Repository Data"
 
 on:
   workflow_call:
+    inputs:
+      timeout_minutes:
+        description: "Max minutes before the job is cancelled (override the measured default)"
+        type: number
+        required: false
+        default: 5
     outputs:
       repository_name:
         description: "Base repository name, without organization"
@@ -14,7 +20,7 @@ jobs:
   extract-data:
     name: "Data Setup"
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: ${{ inputs.timeout_minutes }}
     outputs:
       repository_name: ${{ steps.set_data.outputs.repo_name }}
       image_tag_prefix: ${{ steps.set_data.outputs.image_tag_prefix }}

--- a/.github/workflows/repo-data.yml
+++ b/.github/workflows/repo-data.yml
@@ -14,6 +14,7 @@ jobs:
   extract-data:
     name: "Data Setup"
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       repository_name: ${{ steps.set_data.outputs.repo_name }}
       image_tag_prefix: ${{ steps.set_data.outputs.image_tag_prefix }}

--- a/.github/workflows/setup-node-aws-env.yml
+++ b/.github/workflows/setup-node-aws-env.yml
@@ -15,6 +15,7 @@ jobs:
   build:
     name: "Checkout"
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout node-aws-env
         uses: actions/checkout@v6

--- a/.github/workflows/setup-node-aws-env.yml
+++ b/.github/workflows/setup-node-aws-env.yml
@@ -3,6 +3,11 @@ name: "Setup node AWS Env"
 on:
   workflow_call:
     inputs:
+      timeout_minutes:
+        description: "Max minutes before the job is cancelled (override the measured default)"
+        type: number
+        required: false
+        default: 10
       path:
         type: string
         required: false
@@ -15,7 +20,7 @@ jobs:
   build:
     name: "Checkout"
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: ${{ inputs.timeout_minutes }}
     steps:
       - name: Checkout node-aws-env
         uses: actions/checkout@v6

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -21,6 +21,7 @@ jobs:
   terraform:
     name: "Terraform"
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -3,6 +3,11 @@ name: "Terraform"
 on:
   workflow_call:
     inputs:
+      timeout_minutes:
+        description: "Max minutes before the job is cancelled (override the measured default)"
+        type: number
+        required: false
+        default: 30
       tf_version:
         required: false
         type: string
@@ -21,7 +26,7 @@ jobs:
   terraform:
     name: "Terraform"
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: ${{ inputs.timeout_minutes }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -310,7 +310,7 @@ The workflow implements an optimized Go caching strategy based on https://danp.n
 - **SSH Agent**: Conditionally configured only when SSH key provided
 - **Cache Strategy**: Go workflows use date-based cache keys
 - **Role Duration**: Lambda deployments use 900-second role sessions
-- **Job Timeouts**: Every job sets `timeout-minutes` so a hung step fails fast instead of running to GitHub's 6h default. Values are sized at ~2-4x the observed p90/max run time (sampled from real org CI): trivial script/PR jobs 5 min; npm/NuGet/docker build jobs 10-20 min; Cypress/Terraform 30 min. When adding a new workflow, set a timeout. Note: `timeout-minutes` cannot be set on a job that calls a reusable workflow via `uses:` (e.g. `build-deploy-netcore-library.yml`) — the timeout must live on the leaf job inside the called workflow.
+- **Job Timeouts**: Every job sets `timeout-minutes` so a hung step fails fast instead of running to GitHub's 6h default. Values are sized at ~2-4x the observed p90/max run time (sampled from real org CI): trivial script/PR jobs 5 min; npm/NuGet/docker build jobs 10-20 min; Cypress/Terraform 30 min. Each workflow exposes an optional `timeout_minutes` input (`type: number`, default = the measured value) wired as `timeout-minutes: ${{ inputs.timeout_minutes }}`, so callers can override per-repo without changing the shared workflow. Only `inputs`/`vars` contexts are valid in that expression (not `secrets`). When adding a new workflow, add the input + timeout. Note: `timeout-minutes` cannot be set on a job that calls a reusable workflow via `uses:` (e.g. `build-deploy-netcore-library.yml`) — there the input is forwarded down to the leaf job inside the called workflow (`build-netcore-library.yml`).
 
 ## Instructions for AI Assistants
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -310,6 +310,7 @@ The workflow implements an optimized Go caching strategy based on https://danp.n
 - **SSH Agent**: Conditionally configured only when SSH key provided
 - **Cache Strategy**: Go workflows use date-based cache keys
 - **Role Duration**: Lambda deployments use 900-second role sessions
+- **Job Timeouts**: Every job sets `timeout-minutes` so a hung step fails fast instead of running to GitHub's 6h default. Values are sized at ~2-4x the observed p90/max run time (sampled from real org CI): trivial script/PR jobs 5 min; npm/NuGet/docker build jobs 10-20 min; Cypress/Terraform 30 min. When adding a new workflow, set a timeout. Note: `timeout-minutes` cannot be set on a job that calls a reusable workflow via `uses:` (e.g. `build-deploy-netcore-library.yml`) — the timeout must live on the leaf job inside the called workflow.
 
 ## Instructions for AI Assistants
 


### PR DESCRIPTION
## Why

None of our shared workflows set `timeout-minutes`, so every job inherits GitHub's **6-hour default**. When a step hangs — like the stalled `playwright install` in understory-io/backoffice#4737 — it burns runner minutes for hours instead of failing fast.

## What

Added per-job `timeout-minutes` to all shared workflows, sized at **~2-4× the observed p90/max run time** sampled from real org CI runs (via the Actions API across representative callers).

| Workflow | Active callers | Max seen | Timeout |
|---|---|---|---|
| repo-data | 75 | 5s | 5 |
| lambda-ecr | 42 | 2.3m | build 10 / deploy 5 |
| glue | 22 | 7.6m | 18 |
| ci-go-mise-lambda | 21 | 9.2m | 20 |
| lambda-netcore-ecr | 12 | 3.6m | build 10 / deploy 5 |
| publish-releases | 12 | 1.9m | 10 |
| ci-go-library-mise | 9 | 3.6m | 15 |
| crowdin-pull-translations | 9 | 1.3m | 5 |
| build-deploy-netcore-library | 8 | 1.2m | (see note) |
| release-drafter-go | 7 | 9s | 5 |
| ci-go-library | 5 | 1.1m | 5 |
| pixel-collector | 4 | 0.5m | 5 |
| create-deployment-prs | 3 | 0.5m | 5 |
| poeditor-check | 1 | 7s | 5 |
| build-netcore-library | nested only | ~1.2m | 5 |
| cypress | **0** | — | 30 (estimate) |
| terraform | **0** | — | 30 (estimate) |
| setup-node-aws-env | **0** | — | 10 (estimate) |

## Notes / caveats

- **No legitimate run would be killed** — smallest margin is `ci-go-mise-lambda` at ~2.2× (20m vs 9.2m observed).
- **`build-deploy-netcore-library`** gets no timeout: all 4 of its jobs call a reusable workflow via `uses:`, where `timeout-minutes` is unsupported. The timeout lives on the leaf `build` job in **`build-netcore-library.yml`** (5m) instead.
- **`cypress`, `terraform`, `setup-node-aws-env`** have **no active org callers** (infra repos use their own inline terraform) — their values are static estimates and these may be dead workflows worth removing.
- **`publish-releases`**: sampled runs skewed to the no-publish PR path; a heavy mono-repo publish could exceed the 1.9m observed, but 10m has headroom.

## Follow-up (not in this PR)

`pixel-collector.yml` and `poeditor-check.yml` end on a `curl` with no `--max-time` — a stuck connection blocks until the job timeout. Adding `--max-time` there would make them resilient independent of the job timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)